### PR TITLE
Replace java.time with kotlinx.datetime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,8 +132,9 @@ dependencies {
     implementation(libs.koin)
     implementation(libs.koin.compose)
 
-    // KotlinX Serialization
+    // KotlinX
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.datetime)
 
     // Room
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/brewthings/app/data/model/RaptPillData.kt
+++ b/app/src/main/java/com/brewthings/app/data/model/RaptPillData.kt
@@ -1,12 +1,13 @@
 package com.brewthings.app.data.model
 
-import java.time.Instant
 import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.sqrt
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 data class RaptPillData(
-    val timestamp: Instant = Instant.now(),
+    val timestamp: Instant = Clock.System.now(),
     val temperature: Float,
     val gravity: Float,
     val x: Float,
@@ -14,5 +15,5 @@ data class RaptPillData(
     val z: Float,
     val battery: Float
 ) {
-    val floatingAngle: Float = atan2(sqrt(x*x + y*y), z) * (180.0f / PI.toFloat())
+    val floatingAngle: Float = atan2(sqrt(x * x + y * y), z) * (180.0f / PI.toFloat())
 }

--- a/app/src/main/java/com/brewthings/app/data/storage/RaptPillReadings.kt
+++ b/app/src/main/java/com/brewthings/app/data/storage/RaptPillReadings.kt
@@ -1,6 +1,6 @@
 package com.brewthings.app.data.storage
 
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 data class RaptPillReadings(
     val timestamp: Instant,

--- a/app/src/main/java/com/brewthings/app/data/storage/TypeConverters.kt
+++ b/app/src/main/java/com/brewthings/app/data/storage/TypeConverters.kt
@@ -1,12 +1,12 @@
 package com.brewthings.app.data.storage
 
 import androidx.room.TypeConverter
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 class TypeConverters {
   @TypeConverter
-  fun fromTimestamp(value: Long?): Instant? = value?.let { Instant.ofEpochMilli(it) }
+  fun fromTimestamp(value: Long?): Instant? = value?.let { Instant.fromEpochMilliseconds(it) }
 
   @TypeConverter
-  fun dateToTimestamp(instant: Instant?): Long? = instant?.toEpochMilli()
+  fun dateToTimestamp(instant: Instant?): Long? = instant?.toEpochMilliseconds()
 }

--- a/app/src/main/java/com/brewthings/app/ui/screens/scanning/ScanningScreen.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/scanning/ScanningScreen.kt
@@ -65,7 +65,7 @@ import com.brewthings.app.ui.components.ScanPane
 import com.brewthings.app.ui.components.TextWithIcon
 import com.brewthings.app.ui.screens.navigation.Screen
 import com.brewthings.app.ui.theme.Typography
-import java.time.Instant
+import kotlinx.datetime.Instant
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -372,7 +372,7 @@ private fun Pill(
             }
         }
         Column {
-            val maxTimestamp = pill.data.maxOfOrNull { it.timestamp } ?: Instant.EPOCH
+            val maxTimestamp = pill.data.maxOfOrNull { it.timestamp } ?: Instant.DISTANT_PAST
             pill.data.find { it.timestamp == maxTimestamp }?.let { data ->
                 PillData(name = pill.name, macAddress = pill.macAddress, pillData = data, navGraph = navGraph)
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,8 @@ material = "1.12.0"
 navigation = "2.8.0-beta02"
 junit = "4.13.2"
 room = "2.6.1"
-serializationJson = "1.6.3"
+kotlinxSerializationJson = "1.6.3"
+kotlinxDatetime = "0.6.0"
 toml4j = "0.7.2"
 
 [plugins]
@@ -77,8 +78,9 @@ kable = { group = "com.juul.kable", name = "core-android", version.ref = "kable"
 koin = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
 
-# KotlinX Serialization
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serializationJson" }
+# KotlinX
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # Material Design for Jetpack Compose
 compose-material = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial" }


### PR DESCRIPTION
Will be needed to import some code from other projects way more easily. Plus, this library offers more operators.

A custom lint check to report when the wrong datetime is imported would be convenient. I tried to write it, but gave up because AndroidLint, Detekt e Gradle c'han la mamma maiala (sic.).