### PR TITLE
Improve Insights Implementation

### DIFF
--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -1,0 +1,117 @@
+package com.brewthings.app.data.repository
+
+import com.brewthings.app.data.model.Insight
+import com.brewthings.app.data.model.OGInsight
+import com.brewthings.app.data.model.RaptPillData
+import com.brewthings.app.data.model.RaptPillInsights
+import com.brewthings.app.data.storage.RaptPillDao
+import com.brewthings.app.data.storage.toModelItem
+import com.brewthings.app.util.Logger
+import kotlin.math.abs
+import kotlinx.datetime.Instant
+
+class RaptPillInsightsRepository(
+    private val macAddress: String,
+    private val dao: RaptPillDao
+) {
+    private val logger = Logger("RaptPillInsightsRepository")
+
+    private val cache = mutableMapOf<Instant, RaptPillInsights>()
+
+    suspend fun getInsights(timestamp: Instant): RaptPillInsights? {
+        val cachedData = cache[timestamp]
+        if (cachedData != null) return cachedData
+
+        val ogData = dao.getOG(macAddress)?.toModelItem()
+        if (ogData == null) {
+            logger.error("No OG data found for $macAddress")
+            return null
+        }
+
+        val data = dao.getDataAndPrevious(macAddress, timestamp)
+        if (data.isEmpty()) {
+            logger.error("No data found for $macAddress, $timestamp")
+            return null
+        }
+
+        val pillData = data.first().toModelItem()
+        val previousData = data.getOrNull(1)?.toModelItem()
+
+        return calculateInsights(ogData, pillData, previousData).also {
+            cache[timestamp] = it
+        }
+    }
+
+    fun invalidateCache() {
+        cache.clear()
+    }
+
+    private fun calculateInsights(
+        ogData: RaptPillData,
+        pillData: RaptPillData,
+        previousData: RaptPillData?
+    ): RaptPillInsights {
+        if (pillData == ogData) {
+            return RaptPillInsights(
+                timestamp = pillData.timestamp,
+                temperature = Insight(value = pillData.temperature),
+                gravity = Insight(value = pillData.gravity),
+                battery = Insight(value = pillData.battery),
+                tilt = Insight(value = pillData.floatingAngle),
+            )
+        }
+
+        val abv = calculateABV(ogData.gravity, pillData.gravity)
+        val velocity = calculateVelocity(ogData, pillData)?.let { abs(it) }
+        return RaptPillInsights(
+            timestamp = pillData.timestamp,
+            temperature = Insight(
+                value = pillData.temperature,
+                deltaFromPrevious = previousData?.let { pillData.temperature - it.temperature },
+                deltaFromOG = pillData.temperature - ogData.temperature,
+            ),
+            gravity = Insight(
+                value = pillData.gravity,
+                deltaFromPrevious = previousData?.let { pillData.gravity - it.gravity },
+                deltaFromOG = pillData.gravity - ogData.gravity,
+            ),
+            battery = Insight(
+                value = pillData.battery,
+                deltaFromPrevious = previousData?.let { pillData.battery - it.battery },
+                deltaFromOG = pillData.battery - ogData.battery,
+            ),
+            tilt = Insight(
+                value = pillData.floatingAngle,
+                deltaFromPrevious = previousData?.let { pillData.floatingAngle - it.floatingAngle },
+                deltaFromOG = pillData.floatingAngle - ogData.floatingAngle,
+            ),
+            abv = OGInsight(
+                value = abv,
+                deltaFromPrevious = previousData?.let { abv - calculateABV(ogData.gravity, it.gravity) },
+            ),
+            velocity = velocity?.let {
+                OGInsight(
+                    value = it,
+                    deltaFromPrevious = previousData?.let { calculateVelocity(it, pillData) },
+                )
+            },
+        )
+    }
+
+    private fun calculateABV(og: Float, fg: Float): Float {
+        if (og <= 1.0 || fg <= 1.0) {
+            logger.error("Invalid OG or FG values: og=$og, fg=$fg")
+            return 0f
+        }
+        return (og - fg) * 131.25f
+    }
+
+    private fun calculateVelocity(ogData: RaptPillData, fgData: RaptPillData): Float? {
+        val gravityDrop = fgData.gravity - ogData.gravity
+        val timeDifference = (fgData.timestamp - ogData.timestamp).inWholeDays.toFloat()
+        val velocity = gravityDrop / timeDifference
+        return if (velocity.isInfinite() || velocity.isNaN()) {
+            null
+        } else velocity
+    }
+}

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -20,7 +20,10 @@ class RaptPillInsightsRepository(
 
     suspend fun getInsights(timestamp: Instant): RaptPillInsights? {
         val cachedData = cache[timestamp]
-        if (cachedData != null) return cachedData
+        if (cachedData != null) {
+            logger.info("Fetching cached insights for $timestamp.")
+            return cachedData
+        }
 
         val ogData = dao.getOG(macAddress)?.toModelItem()
         if (ogData == null) {
@@ -51,6 +54,11 @@ class RaptPillInsightsRepository(
         pillData: RaptPillData,
         previousData: RaptPillData?
     ): RaptPillInsights {
+        logger.info("Calculating insights for for ${pillData.timestamp}.\n" +
+                "PillData: $pillData.\n" +
+                "Previous: $previousData\n" +
+                "OG: $ogData"
+        )
         if (pillData == ogData) {
             return RaptPillInsights(
                 timestamp = pillData.timestamp,

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillRepository.kt
@@ -6,6 +6,8 @@ import com.brewthings.app.data.model.RaptPillData
 import com.brewthings.app.data.model.ScannedRaptPill
 import com.brewthings.app.data.storage.RaptPillDao
 import com.brewthings.app.data.storage.RaptPillReadings
+import com.brewthings.app.data.storage.toDataItem
+import com.brewthings.app.data.storage.toModelItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -55,19 +57,3 @@ class RaptPillRepository(
             data.map { it.toModelItem() }
         }
 }
-
-private fun RaptPill.toDataItem() = com.brewthings.app.data.storage.RaptPill(
-    macAddress = macAddress,
-    name = name,
-)
-
-private fun com.brewthings.app.data.storage.RaptPillData.toModelItem(): RaptPillData =
-    RaptPillData(
-        timestamp = readings.timestamp,
-        temperature = readings.temperature,
-        gravity = readings.gravity,
-        x = readings.x,
-        y = readings.y,
-        z = readings.z,
-        battery = readings.battery,
-    )

--- a/app/src/main/java/com/brewthings/app/data/storage/ModelConverters.kt
+++ b/app/src/main/java/com/brewthings/app/data/storage/ModelConverters.kt
@@ -1,0 +1,17 @@
+package com.brewthings.app.data.storage
+
+
+fun com.brewthings.app.data.model.RaptPill.toDataItem() = RaptPill(
+    macAddress = macAddress,
+    name = name,
+)
+
+fun RaptPillData.toModelItem() = com.brewthings.app.data.model.RaptPillData(
+    timestamp = readings.timestamp,
+    temperature = readings.temperature,
+    gravity = readings.gravity,
+    x = readings.x,
+    y = readings.y,
+    z = readings.z,
+    battery = readings.battery,
+)

--- a/app/src/main/java/com/brewthings/app/data/storage/RaptPillDao.kt
+++ b/app/src/main/java/com/brewthings/app/data/storage/RaptPillDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 @Dao
 interface RaptPillDao {
@@ -20,6 +21,23 @@ interface RaptPillDao {
                 "WHERE RaptPill.macAddress = :macAddress"
     )
     fun observeData(macAddress: String): Flow<List<RaptPillData>>
+
+    @Query(
+        "SELECT * FROM RaptPillData " +
+                "JOIN RaptPill ON RaptPill.pillId = RaptPillData.pillId " +
+                "WHERE RaptPill.macAddress = :macAddress " +
+                "AND RaptPillData.timestamp <= :timestamp " +
+                "ORDER BY RaptPillData.timestamp DESC LIMIT 2"
+    )
+    suspend fun getDataAndPrevious(macAddress: String, timestamp: Instant): List<RaptPillData>
+
+    @Query(
+        "SELECT * FROM RaptPillData " +
+                "JOIN RaptPill ON RaptPill.pillId = RaptPillData.pillId " +
+                "WHERE RaptPill.macAddress = :macAddress " +
+                "ORDER BY RaptPillData.timestamp ASC LIMIT 1"
+    )
+    suspend fun getOG(macAddress: String): RaptPillData? // TODO: change to query set OG.
 
     @Query("SELECT pillId FROM RaptPill WHERE macAddress = :macAddress")
     suspend fun getPillIdByMacAddress(macAddress: String): Long?

--- a/app/src/main/java/com/brewthings/app/data/storage/RaptPillDao.kt
+++ b/app/src/main/java/com/brewthings/app/data/storage/RaptPillDao.kt
@@ -29,7 +29,7 @@ interface RaptPillDao {
                 "AND RaptPillData.timestamp <= :timestamp " +
                 "ORDER BY RaptPillData.timestamp DESC LIMIT 2"
     )
-    suspend fun getDataAndPrevious(macAddress: String, timestamp: Instant): List<RaptPillData>
+    fun observeDataAndPrevious(macAddress: String, timestamp: Instant): Flow<List<RaptPillData>>
 
     @Query(
         "SELECT * FROM RaptPillData " +
@@ -37,7 +37,7 @@ interface RaptPillDao {
                 "WHERE RaptPill.macAddress = :macAddress " +
                 "ORDER BY RaptPillData.timestamp ASC LIMIT 1"
     )
-    suspend fun getOG(macAddress: String): RaptPillData? // TODO: change to query set OG.
+    fun observeOG(macAddress: String): Flow<RaptPillData?> // TODO: change to query set OG.
 
     @Query("SELECT pillId FROM RaptPill WHERE macAddress = :macAddress")
     suspend fun getPillIdByMacAddress(macAddress: String): Long?

--- a/app/src/main/java/com/brewthings/app/di/Koin.kt
+++ b/app/src/main/java/com/brewthings/app/di/Koin.kt
@@ -1,6 +1,7 @@
 package com.brewthings.app.di
 
 import com.brewthings.app.data.ble.RaptPillScanner
+import com.brewthings.app.data.repository.RaptPillInsightsRepository
 import com.brewthings.app.data.repository.RaptPillRepository
 import com.brewthings.app.data.storage.RaptPillDatabase
 import com.brewthings.app.ui.screens.graph.GraphScreenViewModel
@@ -14,6 +15,7 @@ val appModule = module {
     single { RaptPillDatabase.create(context = androidContext()) }
     factory { get<RaptPillDatabase>().raptPillDao() }
     factory { RaptPillRepository(scanner = get(), dao = get()) }
-    viewModel { ScanningScreenViewModel(repo = get()) }
-    viewModel { GraphScreenViewModel(repo = get()) }
+    factory { RaptPillInsightsRepository(macAddress = get(), dao = get()) }
+    viewModel { ScanningScreenViewModel() }
+    viewModel { GraphScreenViewModel() }
 }

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphScreenViewModel.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphScreenViewModel.kt
@@ -32,6 +32,7 @@ class GraphScreenViewModel(
 
     init {
         loadGraphData(macAddress)
+        loadInsights()
     }
 
     private fun loadGraphData(macAddress: String) {
@@ -42,6 +43,14 @@ class GraphScreenViewModel(
                     graphData = data,
                     enabledTypes = data.series.map { it.type }.toSet()
                 )
+            }
+        }
+    }
+
+    private fun loadInsights() {
+        viewModelScope.launch {
+            insightsRepo.selectedInsights.collect { insights ->
+                screenState = screenState.copy(selectedInsights = insights)
             }
         }
     }
@@ -58,12 +67,9 @@ class GraphScreenViewModel(
     }
 
     fun onValueSelected(data: Any?) {
-        val raptPillData = data as RaptPillData // Any? is casted to RaptPillData
         viewModelScope.launch {
-            val selectedInsight = insightsRepo.getInsights(raptPillData.timestamp)
-            if (selectedInsight != null) {
-                screenState = screenState.copy(selectedInsights = selectedInsight)
-            }
+            val raptPillData = data as RaptPillData // Any? is casted to RaptPillData
+            insightsRepo.setTimestamp(raptPillData.timestamp)
         }
     }
 

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphScreenViewModel.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphScreenViewModel.kt
@@ -6,26 +6,19 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.brewthings.app.data.model.DataType
-import com.brewthings.app.data.model.Insight
-import com.brewthings.app.data.model.OGInsight
 import com.brewthings.app.data.model.RaptPillData
-import com.brewthings.app.data.model.RaptPillInsights
+import com.brewthings.app.data.repository.RaptPillInsightsRepository
 import com.brewthings.app.data.repository.RaptPillRepository
 import com.brewthings.app.ui.screens.navigation.legacy.ParameterHolder
-import com.brewthings.app.util.Logger
-import kotlin.math.abs
 import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.parameter.parametersOf
 
 class GraphScreenViewModel(
-    private val repo: RaptPillRepository,
-) : ViewModel() {
-    private val name: String? = ParameterHolder.Graph.name
-    private val macAddress: String = ParameterHolder.Graph.macAddress ?: error("macAddress is required")
-
-    private val logger = Logger("GraphScreenViewModel")
-
-    private var insights: List<RaptPillInsights> = emptyList()
-
+    name: String? = ParameterHolder.Graph.name,
+    macAddress: String = ParameterHolder.Graph.macAddress ?: error("macAddress is required")
+) : ViewModel(), KoinComponent {
     var screenState: GraphScreenState by mutableStateOf(
         GraphScreenState(
             title = name ?: macAddress,
@@ -34,6 +27,9 @@ class GraphScreenViewModel(
     )
         private set
 
+    private val repo: RaptPillRepository by inject()
+    private val insightsRepo: RaptPillInsightsRepository by inject { parametersOf(macAddress) }
+
     init {
         loadGraphData(macAddress)
     }
@@ -41,7 +37,6 @@ class GraphScreenViewModel(
     private fun loadGraphData(macAddress: String) {
         viewModelScope.launch {
             repo.observeData(macAddress).collect { pillData ->
-                insights = pillData.toInsights()
                 val data = pillData.toGraphData()
                 screenState = screenState.copy(
                     graphData = data,
@@ -64,9 +59,11 @@ class GraphScreenViewModel(
 
     fun onValueSelected(data: Any?) {
         val raptPillData = data as RaptPillData // Any? is casted to RaptPillData
-        val selectedInsight = insights.find { it.timestamp == raptPillData.timestamp }
-        if (selectedInsight != null) {
-            screenState = screenState.copy(selectedInsights = selectedInsight)
+        viewModelScope.launch {
+            val selectedInsight = insightsRepo.getInsights(raptPillData.timestamp)
+            if (selectedInsight != null) {
+                screenState = screenState.copy(selectedInsights = selectedInsight)
+            }
         }
     }
 
@@ -92,78 +89,5 @@ class GraphScreenViewModel(
             )
         )
         return GraphData(series)
-    }
-
-    private fun List<RaptPillData>.toInsights(): List<RaptPillInsights> {
-        if (isEmpty()) return emptyList()
-
-        val ogData = first() //TODO: get from db.
-
-        return mapIndexed { index, pillData ->
-            if (index == 0 || pillData == ogData) {
-                RaptPillInsights(
-                    timestamp = pillData.timestamp,
-                    temperature = Insight(value = pillData.temperature),
-                    gravity = Insight(value = pillData.gravity),
-                    battery = Insight(value = pillData.battery),
-                    tilt = Insight(value = pillData.floatingAngle),
-                )
-            } else {
-                val abv = calculateABV(ogData.gravity, pillData.gravity)
-                val velocity = calculateVelocity(ogData, pillData)?.let { abs(it) }
-                val previous = get(index - 1)
-                val previousAbv = calculateABV(ogData.gravity, previous.gravity)
-                RaptPillInsights(
-                    timestamp = pillData.timestamp,
-                    temperature = Insight(
-                        value = pillData.temperature,
-                        deltaFromPrevious = pillData.temperature - previous.temperature,
-                        deltaFromOG = pillData.temperature - ogData.temperature,
-                    ),
-                    gravity = Insight(
-                        value = pillData.gravity,
-                        deltaFromPrevious = pillData.gravity - previous.gravity,
-                        deltaFromOG = pillData.gravity - ogData.gravity,
-                    ),
-                    battery = Insight(
-                        value = pillData.battery,
-                        deltaFromPrevious = pillData.battery - previous.battery,
-                        deltaFromOG = pillData.battery - ogData.battery,
-                    ),
-                    tilt = Insight(
-                        value = pillData.floatingAngle,
-                        deltaFromPrevious = pillData.floatingAngle - previous.floatingAngle,
-                        deltaFromOG = pillData.floatingAngle - ogData.floatingAngle,
-                    ),
-                    abv = OGInsight(
-                        value = abv,
-                        deltaFromPrevious = abv - previousAbv,
-                    ),
-                    velocity = velocity?.let {
-                        OGInsight(
-                            value = it,
-                            deltaFromPrevious = calculateVelocity(previous, pillData),
-                        )
-                    },
-                )
-            }
-        }
-    }
-
-    private fun calculateABV(og: Float, fg: Float): Float {
-        if (og <= 1.0 || fg <= 1.0) {
-            logger.error("Invalid OG or FG values: og=$og, fg=$fg")
-            return 0f
-        }
-        return (og - fg) * 131.25f
-    }
-
-    private fun calculateVelocity(ogData: RaptPillData, fgData: RaptPillData): Float? {
-        val gravityDrop = fgData.gravity - ogData.gravity
-        val timeDifference = (fgData.timestamp - ogData.timestamp).inWholeDays.toFloat()
-        val velocity = gravityDrop / timeDifference
-        return if (velocity.isInfinite() || velocity.isNaN()) {
-            null
-        } else velocity
     }
 }

--- a/app/src/main/java/com/brewthings/app/ui/screens/scanning/ScanningScreenViewModel.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/scanning/ScanningScreenViewModel.kt
@@ -15,12 +15,14 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class ScanningScreenViewModel(
-    private val repo: RaptPillRepository
-) : ViewModel() {
+class ScanningScreenViewModel : ViewModel(), KoinComponent {
     var screenState: ScanningScreenState by mutableStateOf(ScanningScreenState())
         private set
+
+    private val repo: RaptPillRepository by inject()
 
     private var scanJob: Job? = null
     private val scannedRaptPills: MutableList<ScannedRaptPill> = mutableListOf()


### PR DESCRIPTION
before: all the insights were calculated at graph loading time, and cached in memory.
now, each insight gets calculated when selected in the graph, by fetching the data from the DB; it is then cached for faster retrieval on a second query.

The new repo is implemented unidirectionally, and will be ready for introducing configurable OG.