### PR TITLE
Improve graph deselection and time formatting

### DIFF
--- a/app/src/main/java/com/brewthings/app/data/model/RaptPillInsights.kt
+++ b/app/src/main/java/com/brewthings/app/data/model/RaptPillInsights.kt
@@ -1,5 +1,6 @@
 package com.brewthings.app.data.model
 
+import kotlin.time.Duration
 import kotlinx.datetime.Instant
 
 data class RaptPillInsights(
@@ -10,6 +11,7 @@ data class RaptPillInsights(
     val battery: Insight,
     val abv: OGInsight? = null,
     val velocity: OGInsight? = null,
+    val durationFromOG: Duration? = null,
 )
 
 data class Insight(

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -125,6 +125,7 @@ class RaptPillInsightsRepository(
                     deltaFromPrevious = previousData?.let { calculateVelocity(it, pillData) },
                 )
             },
+            durationFromOG = pillData.timestamp - ogData.timestamp,
         )
     }
 

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -41,7 +41,7 @@ class RaptPillInsightsRepository(
             }
         }
 
-    suspend fun setTimestamp(timestamp: Instant) {
+    suspend fun setTimestamp(timestamp: Instant?) {
         selectedTimestamp.emit(timestamp)
     }
 

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -125,7 +125,7 @@ class RaptPillInsightsRepository(
                     deltaFromPrevious = previousData?.let { calculateVelocity(it, pillData) },
                 )
             },
-            durationFromOG = pillData.timestamp - ogData.timestamp,
+            durationFromOG = ogData.timestamp - pillData.timestamp,
         )
     }
 

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -52,11 +52,6 @@ class RaptPillInsightsRepository(
             return cachedData
         }
 
-        if (ogData == null) {
-            logger.error("No OG data found for $macAddress")
-            return null
-        }
-
         if (data.isEmpty()) {
             logger.error("No data found for $macAddress, $timestamp")
             return null
@@ -76,7 +71,7 @@ class RaptPillInsightsRepository(
     }
 
     private fun calculateInsights(
-        ogData: RaptPillData,
+        ogData: RaptPillData?,
         pillData: RaptPillData,
         previousData: RaptPillData?
     ): RaptPillInsights {
@@ -86,7 +81,7 @@ class RaptPillInsightsRepository(
                     "Previous: $previousData\n" +
                     "OG: $ogData"
         )
-        if (pillData == ogData) {
+        if (ogData == null || pillData == ogData) {
             return RaptPillInsights(
                 timestamp = pillData.timestamp,
                 temperature = Insight(value = pillData.temperature),

--- a/app/src/main/java/com/brewthings/app/ui/android/chart/MpAndroidLineChart.kt
+++ b/app/src/main/java/com/brewthings/app/ui/android/chart/MpAndroidLineChart.kt
@@ -40,7 +40,7 @@ class MpAndroidLineChart(
         }
 
         override fun onNothingSelected() {
-            // do nothing.
+            onValueSelected(null)
         }
     }
 

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
@@ -45,7 +45,7 @@ fun GraphInsights(data: RaptPillInsights) {
                 Text(
                     modifier = Modifier.padding(top = 4.dp),
                     text = stringResource(
-                        id = R.string.graph_data_duration_since_brew,
+                        id = R.string.graph_data_duration_since_og,
                         data.durationFromOG.toFormattedDuration()
                     ),
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
@@ -29,6 +29,7 @@ import com.brewthings.app.ui.components.IconAlign
 import com.brewthings.app.ui.components.TextWithIcon
 import com.brewthings.app.ui.theme.BrewthingsTheme
 import com.brewthings.app.util.datetime.toFormattedDate
+import com.brewthings.app.util.datetime.toFormattedDuration
 import kotlin.math.abs
 import kotlinx.datetime.Instant
 
@@ -40,6 +41,16 @@ fun GraphInsights(data: RaptPillInsights) {
                 text = data.timestamp.toFormattedDate(),
                 style = MaterialTheme.typography.bodyMedium,
             )
+            data.durationFromOG?.also {
+                Text(
+                    modifier = Modifier.padding(top = 4.dp),
+                    text = stringResource(
+                        id = R.string.graph_data_duration_since_brew,
+                        data.durationFromOG.toFormattedDuration()
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
 
             InsightsRow(
                 icon = { Spacer(modifier = Modifier.size(24.dp)) },
@@ -210,10 +221,12 @@ private fun Float.asArrowDropIcon(): Int? = when {
 @Preview(apiLevel = 33) // workaround for AS Hedgehog and below
 @Composable
 fun GraphInsightsPreview() {
+    val timestamp = Instant.parse("2024-06-01T15:46:31Z")
+    val timestampOG = Instant.parse("2024-05-26T00:00:00Z")
     BrewthingsTheme {
         GraphInsights(
             data = RaptPillInsights(
-                timestamp = Instant.fromEpochMilliseconds(1716738391308L),
+                timestamp = timestamp,
                 temperature = Insight(
                     value = 22.43f,
                     deltaFromOG = 5.3f,
@@ -239,7 +252,8 @@ fun GraphInsightsPreview() {
                 velocity = OGInsight(
                     value = 0.020f,
                     deltaFromPrevious = -0.002f,
-                )
+                ),
+                durationFromOG = timestamp - timestampOG,
             )
         )
     }

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
@@ -253,7 +253,7 @@ fun GraphInsightsPreview() {
                     value = 0.020f,
                     deltaFromPrevious = -0.002f,
                 ),
-                durationFromOG = timestamp - timestampOG,
+                durationFromOG = timestampOG - timestamp,
             )
         )
     }

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
@@ -37,20 +37,7 @@ import kotlinx.datetime.Instant
 fun GraphInsights(data: RaptPillInsights) {
     Card {
         Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = data.timestamp.toFormattedDate(),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            data.durationFromOG?.also {
-                Text(
-                    modifier = Modifier.padding(top = 4.dp),
-                    text = stringResource(
-                        id = R.string.graph_data_duration_since_og,
-                        data.durationFromOG.toFormattedDuration()
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
+            InsightsTimeHeader(data)
 
             InsightsRow(
                 icon = { Spacer(modifier = Modifier.size(24.dp)) },
@@ -114,6 +101,33 @@ fun GraphInsights(data: RaptPillInsights) {
 }
 
 @Composable
+fun InsightsTimeHeader(data: RaptPillInsights) {
+    Row(
+        modifier = Modifier.padding(bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        InsightIcon(iconResId = R.drawable.ic_calendar)
+        Spacer(modifier = Modifier.size(16.dp))
+        Column {
+            Text(
+                text = data.timestamp.toFormattedDate(),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            data.durationFromOG?.also {
+                Text(
+                    modifier = Modifier.padding(top = 4.dp),
+                    text = stringResource(
+                        id = R.string.graph_data_duration_since_og,
+                        data.durationFromOG.toFormattedDuration()
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+
+@Composable
 fun InsightsRow(
     modifier: Modifier = Modifier,
     icon: @Composable (Modifier) -> Unit,
@@ -140,7 +154,7 @@ fun InsightsRow(
 
 @Composable
 fun InsightHeader(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     @StringRes headerResId: Int,
 ) {
     Text(
@@ -155,11 +169,11 @@ fun InsightHeader(
 
 @Composable
 fun InsightIcon(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     @DrawableRes iconResId: Int,
 ) {
     Icon(
-        modifier = Modifier.size(24.dp),
+        modifier = modifier.size(24.dp),
         painter = painterResource(id = iconResId),
         contentDescription = null,
         tint = MaterialTheme.colorScheme.primary
@@ -168,7 +182,7 @@ fun InsightIcon(
 
 @Composable
 fun InsightLabel(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     @StringRes labelResId: Int,
 ) {
     Text(
@@ -180,7 +194,7 @@ fun InsightLabel(
 
 @Composable
 fun InsightValue(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     @StringRes textResId: Int,
     value: Float,
 ) {
@@ -194,7 +208,7 @@ fun InsightValue(
 
 @Composable
 fun InsightDelta(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     @StringRes textResId: Int,
     delta: Float?,
 ) {

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphScreenViewModel.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphScreenViewModel.kt
@@ -68,8 +68,8 @@ class GraphScreenViewModel(
 
     fun onValueSelected(data: Any?) {
         viewModelScope.launch {
-            val raptPillData = data as RaptPillData // Any? is casted to RaptPillData
-            insightsRepo.setTimestamp(raptPillData.timestamp)
+            val raptPillData = data as RaptPillData? // Any? is casted to RaptPillData?
+            insightsRepo.setTimestamp(raptPillData?.timestamp)
         }
     }
 

--- a/app/src/main/java/com/brewthings/app/util/datetime/FormattedDate.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/FormattedDate.kt
@@ -25,6 +25,8 @@ fun Instant.toFormattedDate(
     when {
         // Only minutes have passed since now.
         days == 0L && hours == 0L -> when {
+            isYesterday(date = date, now = now, timeZone = timeZone) -> return date.toFormatYesterday(timeZone)
+
             (0 downTo -1L).contains(minutes) ->
                 return stringResource(R.string.formatted_date_less_than_a_minute)
 
@@ -33,10 +35,12 @@ fun Instant.toFormattedDate(
         }
 
         // Only hours and minutes have passed since now.
-        days == 0L -> when (hours) {
-            -1L ->
+        days == 0L -> when {
+            isYesterday(date = date, now = now, timeZone = timeZone) -> return date.toFormatYesterday(timeZone)
+
+            hours == -1L ->
                 return stringResource(R.string.formatted_date_hour_ago)
-            in -2 downTo -23L ->
+            hours in -2 downTo -23L ->
                 return stringResource(R.string.formatted_date_hours_ago, abs(hours))
         }
 
@@ -45,8 +49,10 @@ fun Instant.toFormattedDate(
             val diffFromStartOfDay = date - startOfDay
             val (daysFromStartOfDay, _, _) = diffFromStartOfDay.getDaysHoursAndMinutes()
 
-            when (daysFromStartOfDay) {
-                in -1L downTo -6L -> {
+            when  {
+                isYesterday(date = date, now = now, timeZone = timeZone) -> return date.toFormatYesterday(timeZone)
+
+                daysFromStartOfDay in -1L downTo -6L -> {
                     val lastWeekday = stringResource(
                         id = R.string.formatted_date_last_weekday,
                         date.formatDateTime("EEEE", timeZone)
@@ -60,3 +66,7 @@ fun Instant.toFormattedDate(
     // Covering both dates older than 1 week ago and dates in the future.
     return date.formatDateTime("MMM d, yyyy, HH:mm", timeZone)
 }
+
+@Composable
+private fun Instant.toFormatYesterday(timeZone: TimeZone) =
+   "${stringResource(id = R.string.formatted_date_yesterday)}, ${formatDateTime("MMM d, HH:mm", timeZone)}"

--- a/app/src/main/java/com/brewthings/app/util/datetime/FormattedDate.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/FormattedDate.kt
@@ -26,7 +26,7 @@ fun Instant.toFormattedDate(
         // Only minutes have passed since now.
         days == 0L && hours == 0L -> when {
             (0 downTo -1L).contains(minutes) ->
-                return stringResource(R.string.formatted_date_just_now)
+                return stringResource(R.string.formatted_date_less_than_a_minute)
 
             (-2 downTo -59L).contains(minutes) ->
                 return stringResource(R.string.formatted_date_minutes_ago, abs(minutes))
@@ -46,12 +46,17 @@ fun Instant.toFormattedDate(
             val (daysFromStartOfDay, _, _) = diffFromStartOfDay.getDaysHoursAndMinutes()
 
             when (daysFromStartOfDay) {
-                in -1L downTo -6L ->
-                    return date.formatDateTime("EEEE, HH:mm", timeZone)
+                in -1L downTo -6L -> {
+                    val lastWeekday = stringResource(
+                        id = R.string.formatted_date_last_weekday,
+                        date.formatDateTime("EEEE", timeZone)
+                    )
+                    return "$lastWeekday, ${date.formatDateTime("MMM d, HH:mm", timeZone)}"
+                }
             }
         }
     }
 
     // Covering both dates older than 1 week ago and dates in the future.
-    return date.formatDateTime("MMM d, HH:mm", timeZone)
+    return date.formatDateTime("MMM d, yyyy, HH:mm", timeZone)
 }

--- a/app/src/main/java/com/brewthings/app/util/datetime/FormattedDuration.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/FormattedDuration.kt
@@ -1,0 +1,38 @@
+package com.brewthings.app.util.datetime
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.brewthings.app.R
+import kotlin.math.abs
+import kotlin.time.Duration
+
+@Composable
+fun Duration.toFormattedDuration(): String {
+    if (this.isNegative()) { return "" }
+
+    val (days, hours, minutes) = getDaysHoursAndMinutes()
+
+    when {
+        // Only minutes have passed since now.
+        days == 0L && hours == 0L -> when {
+            (0 downTo -1L).contains(minutes) ->
+                return stringResource(R.string.formatted_duration_less_than_a_minute)
+
+            (-2 downTo -59L).contains(minutes) ->
+                return stringResource(R.string.formatted_duration_minutes, abs(minutes))
+        }
+
+        // Only hours and minutes have passed since now.
+        days == 0L -> when (hours) {
+            -1L ->
+                return stringResource(R.string.formatted_duration_hour)
+            in -2 downTo -23L ->
+                return stringResource(R.string.formatted_duration_hours, abs(hours))
+        }
+
+        days == 1L -> return stringResource(R.string.formatted_duration_day)
+    }
+
+    // Covering dates older than 24 hours ago.
+    return  stringResource(R.string.formatted_duration_days, abs(days))
+}

--- a/app/src/main/java/com/brewthings/app/util/datetime/FormattedDuration.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/FormattedDuration.kt
@@ -8,12 +8,12 @@ import kotlin.time.Duration
 
 @Composable
 fun Duration.toFormattedDuration(): String {
-    if (this.isNegative()) { return "" }
+    if (this.isPositive()) { return "" }
 
     val (days, hours, minutes) = getDaysHoursAndMinutes()
 
     when {
-        // Only minutes have passed since now.
+        // Only minutes have passed.
         days == 0L && hours == 0L -> when {
             (0 downTo -1L).contains(minutes) ->
                 return stringResource(R.string.formatted_duration_less_than_a_minute)
@@ -22,7 +22,7 @@ fun Duration.toFormattedDuration(): String {
                 return stringResource(R.string.formatted_duration_minutes, abs(minutes))
         }
 
-        // Only hours and minutes have passed since now.
+        // Only hours and minutes have passed.
         days == 0L -> when (hours) {
             -1L ->
                 return stringResource(R.string.formatted_duration_hour)
@@ -30,7 +30,7 @@ fun Duration.toFormattedDuration(): String {
                 return stringResource(R.string.formatted_duration_hours, abs(hours))
         }
 
-        days == 1L -> return stringResource(R.string.formatted_duration_day)
+        days == -1L -> return stringResource(R.string.formatted_duration_day)
     }
 
     // Covering dates older than 24 hours ago.

--- a/app/src/main/java/com/brewthings/app/util/datetime/FormattedDuration.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/FormattedDuration.kt
@@ -8,29 +8,27 @@ import kotlin.time.Duration
 
 @Composable
 fun Duration.toFormattedDuration(): String {
-    if (this.isPositive()) { return "" }
-
-    val (days, hours, minutes) = getDaysHoursAndMinutes()
+    val (days, hours, minutes) = absoluteValue.getDaysHoursAndMinutes()
 
     when {
         // Only minutes have passed.
         days == 0L && hours == 0L -> when {
-            (0 downTo -1L).contains(minutes) ->
+            (0..1L).contains(minutes) ->
                 return stringResource(R.string.formatted_duration_less_than_a_minute)
 
-            (-2 downTo -59L).contains(minutes) ->
+            (2..59L).contains(minutes) ->
                 return stringResource(R.string.formatted_duration_minutes, abs(minutes))
         }
 
         // Only hours and minutes have passed.
         days == 0L -> when (hours) {
-            -1L ->
+            1L ->
                 return stringResource(R.string.formatted_duration_hour)
-            in -2 downTo -23L ->
+            in 2..23L ->
                 return stringResource(R.string.formatted_duration_hours, abs(hours))
         }
 
-        days == -1L -> return stringResource(R.string.formatted_duration_day)
+        days == 1L -> return stringResource(R.string.formatted_duration_day)
     }
 
     // Covering dates older than 24 hours ago.

--- a/app/src/main/res/drawable/ic_calendar.xml
+++ b/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.89,4 3.01,4.9 3.01,6L3,20c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6C21,4.9 20.1,4 19,4zM19,20H5V10h14V20zM19,8H5V6h14V8zM9,14H7v-2h2V14zM13,14h-2v-2h2V14zM17,14h-2v-2h2V14zM9,18H7v-2h2V18zM13,18h-2v-2h2V18zM17,18h-2v-2h2V18z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,12 +38,21 @@
     <string name="graph_data_label_tilt">Tilt</string>
     <string name="graph_data_label_abv">ABV</string>
     <string name="graph_data_label_velocity">SG/day</string>
+    <string name="graph_data_duration_since_brew">%s since the start</string>
     <string name="graph_header_name">Name</string>
     <string name="graph_header_value">Value</string>
     <string name="graph_header_from_previous">Δ prev.</string>
     <string name="graph_header_from_og">Δ OG</string>
-    <string name="formatted_date_just_now">Just now</string>
+    <string name="formatted_date_less_than_a_minute">Just now</string>
     <string name="formatted_date_minutes_ago">%d minutes ago</string>
     <string name="formatted_date_hour_ago">an hour ago</string>
     <string name="formatted_date_hours_ago">%d hours ago</string>
+    <string name="formatted_date_yesterday">Yesterday</string>
+    <string name="formatted_date_last_weekday">Last %s</string>
+    <string name="formatted_duration_less_than_a_minute">One minute or less</string>
+    <string name="formatted_duration_minutes">%d minutes</string>
+    <string name="formatted_duration_hour">One hour</string>
+    <string name="formatted_duration_hours">%d hours</string>
+    <string name="formatted_duration_day">One day</string>
+    <string name="formatted_duration_days">%d days</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="graph_data_label_tilt">Tilt</string>
     <string name="graph_data_label_abv">ABV</string>
     <string name="graph_data_label_velocity">SG/day</string>
-    <string name="graph_data_duration_since_brew">%s since the start</string>
+    <string name="graph_data_duration_since_og">%s since OG</string>
     <string name="graph_header_name">Name</string>
     <string name="graph_header_value">Value</string>
     <string name="graph_header_from_previous">Δ prev.</string>


### PR DESCRIPTION
When you deselect a point, now the card disappears accordingly.

The insights card now has a dedicated header and icon, showing the date of the measurement as well as the distance from OG.

Formatting date rules have been improved.

<img src="https://github.com/SeTzener/Brewthings/assets/3224791/425da6e3-7fcd-4e4b-9350-35c5110c285d" width=400/>
