### PR TITLE
Fix diff in days

### DIFF
--- a/app/src/main/java/com/brewthings/app/data/model/RaptPillInsights.kt
+++ b/app/src/main/java/com/brewthings/app/data/model/RaptPillInsights.kt
@@ -1,6 +1,6 @@
 package com.brewthings.app.data.model
 
-import kotlin.time.Duration
+import com.brewthings.app.util.datetime.TimeRange
 import kotlinx.datetime.Instant
 
 data class RaptPillInsights(
@@ -11,7 +11,7 @@ data class RaptPillInsights(
     val battery: Insight,
     val abv: OGInsight? = null,
     val velocity: OGInsight? = null,
-    val durationFromOG: Duration? = null,
+    val durationFromOG: TimeRange? = null,
 )
 
 data class Insight(

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -7,6 +7,7 @@ import com.brewthings.app.data.model.RaptPillInsights
 import com.brewthings.app.data.storage.RaptPillDao
 import com.brewthings.app.data.storage.toModelItem
 import com.brewthings.app.util.Logger
+import com.brewthings.app.util.datetime.TimeRange
 import com.brewthings.app.util.datetime.daysBetweenIgnoringTime
 import kotlin.math.abs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -126,7 +127,7 @@ class RaptPillInsightsRepository(
                     deltaFromPrevious = previousData?.let { calculateVelocity(it, pillData) },
                 )
             },
-            durationFromOG = ogData.timestamp - pillData.timestamp,
+            durationFromOG = TimeRange(ogData.timestamp, pillData.timestamp),
         )
     }
 

--- a/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
+++ b/app/src/main/java/com/brewthings/app/data/repository/RaptPillInsightsRepository.kt
@@ -7,6 +7,7 @@ import com.brewthings.app.data.model.RaptPillInsights
 import com.brewthings.app.data.storage.RaptPillDao
 import com.brewthings.app.data.storage.toModelItem
 import com.brewthings.app.util.Logger
+import com.brewthings.app.util.datetime.daysBetweenIgnoringTime
 import kotlin.math.abs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -139,7 +140,7 @@ class RaptPillInsightsRepository(
 
     private fun calculateVelocity(ogData: RaptPillData, fgData: RaptPillData): Float? {
         val gravityDrop = fgData.gravity - ogData.gravity
-        val timeDifference = (fgData.timestamp - ogData.timestamp).inWholeDays.toFloat()
+        val timeDifference = daysBetweenIgnoringTime(fgData.timestamp, ogData.timestamp).toFloat()
         val velocity = gravityDrop / timeDifference
         return if (velocity.isInfinite() || velocity.isNaN()) {
             null

--- a/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
+++ b/app/src/main/java/com/brewthings/app/ui/screens/graph/GraphInsights.kt
@@ -28,8 +28,9 @@ import com.brewthings.app.ui.components.BatteryLevelIndicator
 import com.brewthings.app.ui.components.IconAlign
 import com.brewthings.app.ui.components.TextWithIcon
 import com.brewthings.app.ui.theme.BrewthingsTheme
+import com.brewthings.app.util.datetime.TimeRange
+import com.brewthings.app.util.datetime.format
 import com.brewthings.app.util.datetime.toFormattedDate
-import com.brewthings.app.util.datetime.toFormattedDuration
 import kotlin.math.abs
 import kotlinx.datetime.Instant
 
@@ -118,7 +119,7 @@ fun InsightsTimeHeader(data: RaptPillInsights) {
                     modifier = Modifier.padding(top = 4.dp),
                     text = stringResource(
                         id = R.string.graph_data_duration_since_og,
-                        data.durationFromOG.toFormattedDuration()
+                        it.format()
                     ),
                     style = MaterialTheme.typography.bodySmall,
                 )
@@ -267,7 +268,7 @@ fun GraphInsightsPreview() {
                     value = 0.020f,
                     deltaFromPrevious = -0.002f,
                 ),
-                durationFromOG = timestampOG - timestamp,
+                durationFromOG = TimeRange(timestampOG, timestamp),
             )
         )
     }

--- a/app/src/main/java/com/brewthings/app/util/Utils.kt
+++ b/app/src/main/java/com/brewthings/app/util/Utils.kt
@@ -12,6 +12,3 @@ fun ByteArray.asHexString(prefix: String = "0x"): String = joinToString(
 
 fun Byte.asHexString(prefix: String = "0x"): String =
     "$prefix${String.format(Locale.ENGLISH, "%02X", this)}"
-
-inline fun <T> Iterable<T>.maxOfOrDefault(default: Float = 1f, selector: (T) -> Float): Float =
-    maxOf(selector).takeIf { !it.isNaN() } ?: default

--- a/app/src/main/java/com/brewthings/app/util/datetime/FormattedDate.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/FormattedDate.kt
@@ -15,7 +15,6 @@ fun Instant.toFormattedDate(
     timeZone: TimeZone = TimeZone.currentSystemDefault()
 ): String {
     val now = clock.now()
-    val startOfDay = startOfDay(now = now, timeZone = timeZone)
     val date = this
 
     // Diff will have negative values for past dates, positive values for future dates.
@@ -46,13 +45,10 @@ fun Instant.toFormattedDate(
 
         // Days, hours and minutes have passed since now.
         days != 0L -> {
-            val diffFromStartOfDay = date - startOfDay
-            val (daysFromStartOfDay, _, _) = diffFromStartOfDay.getDaysHoursAndMinutes()
-
             when  {
                 isYesterday(date = date, now = now, timeZone = timeZone) -> return date.toFormatYesterday(timeZone)
 
-                daysFromStartOfDay in -1L downTo -6L -> {
+                daysBetweenIgnoringTime(date, now) in -1 downTo -6 -> {
                     val lastWeekday = stringResource(
                         id = R.string.formatted_date_last_weekday,
                         date.formatDateTime("EEEE", timeZone)

--- a/app/src/main/java/com/brewthings/app/util/datetime/Functions.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/Functions.kt
@@ -4,13 +4,9 @@ import java.time.format.DateTimeFormatter
 import kotlin.math.roundToLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
-import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.daysUntil
-import kotlinx.datetime.plus
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
 
@@ -45,38 +41,8 @@ fun isYesterday(date: Instant, now: Instant, timeZone: TimeZone): Boolean {
     return localOffsetDate.dayOfYear == nowLocalDate.dayOfYear
 }
 
-/**
- * Returns the default [TimeZone] of the system.
- */
-fun systemTimeZone(): TimeZone = TimeZone.currentSystemDefault()
-
-/**
- * Merges two ranges into one. The resulting range is from the minimal start value of both ranges to the maximal end
- * values of both ranges.
- */
-fun <T : Comparable<T>> ClosedRange<T>.mergeWith(range: ClosedRange<T>): ClosedRange<T> =
-    minOf(start, range.start)..maxOf(endInclusive, range.endInclusive)
-
 fun ClosedRange<Instant>.contains(otherRange: ClosedRange<Instant>): Boolean =
     contains(otherRange.start) && contains(otherRange.endInclusive)
-
-/**
- * Get the current instant.
- */
-fun now(): Instant = Clock.System.now()
-
-/**
- * Get the current [Instant] rounded to the current hour.
- */
-fun currentHour(): Instant =
-    Instant.fromEpochSeconds(now().epochSeconds.floorSecToHour())
-
-fun startOfDay(now: Instant = now(), timeZone: TimeZone = systemTimeZone()): Instant {
-    return now
-        .toLocalDateTime(timeZone)
-        .date
-        .atStartOfDayIn(timeZone)
-}
 
 /**
  * Rounds the given milliseconds since epoch [Long] to the closest hour.
@@ -84,31 +50,9 @@ fun startOfDay(now: Instant = now(), timeZone: TimeZone = systemTimeZone()): Ins
 fun Long.roundMsToHour(): Long =
     HOUR_IN_MS * msToHours().roundToLong()
 
-/**
- * Rounds the given seconds since epoch [Long] to the closest hour.
- */
-fun Long.roundSecToHour(): Long =
-    HOUR_IN_SEC * secondsToHours().roundToLong()
-
-/**
- * Rounds down the given seconds since epoch [Long] to the closest hour.
- */
-fun Long.floorSecToHour(): Long =
-    HOUR_IN_SEC * secondsToHours().toLong()
-
-/**
- * Adds one hour to [Instant].
- */
-fun Instant.plusHour(): Instant =
-    plus(1, DateTimeUnit.HOUR)
-
 private fun Long.msToHours(): Double =
     this / HOUR_IN_MS.toDouble()
 
-private fun Long.secondsToHours(): Double =
-    this / HOUR_IN_SEC.toDouble()
-
-const val DAY_IN_SEC = 86400
 internal const val SEC_IN_MS: Long = 1000L
 private const val HOUR_IN_SEC = 60 * 60
 private const val HOUR_IN_MS = HOUR_IN_SEC * SEC_IN_MS

--- a/app/src/main/java/com/brewthings/app/util/datetime/Functions.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/Functions.kt
@@ -9,9 +9,19 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.daysUntil
 import kotlinx.datetime.plus
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
+
+fun daysBetweenIgnoringTime(instant1: Instant, instant2: Instant): Int {
+    // Convert Instants to LocalDate
+    val date1 = instant1.toLocalDateTime(TimeZone.UTC).date
+    val date2 = instant2.toLocalDateTime(TimeZone.UTC).date
+
+    // Calculate the difference in days
+    return date1.daysUntil(date2)
+}
 
 fun Instant.formatDateTime(
     dateTimePattern: String,

--- a/app/src/main/java/com/brewthings/app/util/datetime/Functions.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/Functions.kt
@@ -11,9 +11,10 @@ import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime
 
 fun daysBetweenIgnoringTime(instant1: Instant, instant2: Instant): Int {
+    val timeZone = TimeZone.UTC
     // Convert Instants to LocalDate
-    val date1 = instant1.toLocalDateTime(TimeZone.UTC).date
-    val date2 = instant2.toLocalDateTime(TimeZone.UTC).date
+    val date1 = instant1.toLocalDateTime(timeZone).date
+    val date2 = instant2.toLocalDateTime(timeZone).date
 
     // Calculate the difference in days
     return date1.daysUntil(date2)

--- a/app/src/main/java/com/brewthings/app/util/datetime/TimeRange.kt
+++ b/app/src/main/java/com/brewthings/app/util/datetime/TimeRange.kt
@@ -5,10 +5,15 @@ import androidx.compose.ui.res.stringResource
 import com.brewthings.app.R
 import kotlin.math.abs
 import kotlin.time.Duration
+import kotlinx.datetime.Instant
+
+data class TimeRange(val from: Instant, val to: Instant)
 
 @Composable
-fun Duration.toFormattedDuration(): String {
-    val (days, hours, minutes) = absoluteValue.getDaysHoursAndMinutes()
+fun TimeRange.format(): String {
+    val diff: Duration = to - from
+    val (days, hours, minutes) = diff.getDaysHoursAndMinutes()
+    val daysIgnoringTime = daysBetweenIgnoringTime(from, to)
 
     when {
         // Only minutes have passed.
@@ -28,9 +33,9 @@ fun Duration.toFormattedDuration(): String {
                 return stringResource(R.string.formatted_duration_hours, abs(hours))
         }
 
-        days == 1L -> return stringResource(R.string.formatted_duration_day)
+        daysIgnoringTime == 1 -> return stringResource(R.string.formatted_duration_day)
     }
 
     // Covering dates older than 24 hours ago.
-    return  stringResource(R.string.formatted_duration_days, abs(days))
+    return  stringResource(R.string.formatted_duration_days, daysIgnoringTime)
 }


### PR DESCRIPTION
Use a custom algorithm in Insights to calculate diff in days between dates, so that it ignores time.
This fixes a set of weird results that have been observed from real data.

Used this to double check the result: https://www.timeanddate.com/date/durationresult.html

Boyscout: removed some unused util functions.