### PR TITLE
Test snaphots

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,6 @@ android {
         targetSdk = target
         versionCode = generateVersionCode(semanticVersioning, buildVersion)
         versionName = semanticVersioning
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -145,8 +144,17 @@ dependencies {
     ksp(libs.room.compiler)
 
     // Unit Testing
-    testImplementation(libs.junit)
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.engine)
+    testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.kotest.junit5)
     testImplementation(libs.mockk)
+    testImplementation(libs.karumi)
+    testImplementation(libs.serialization.moshi)
+    testImplementation(libs.serialization.moshi.kotlin)
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 fun generateVersionCode(versionName: String, buildVersion: Int): Int {

--- a/app/src/main/java/com/brewthings/app/data/model/ScannedRaptPillData.kt
+++ b/app/src/main/java/com/brewthings/app/data/model/ScannedRaptPillData.kt
@@ -2,7 +2,9 @@ package com.brewthings.app.data.model
 
 import com.brewthings.app.data.domain.SensorWithTiltReadings
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class ScannedRaptPillData(
     override val timestamp: Instant,
     override val temperature: Float,

--- a/app/src/test/java/com/brewthings/app/data/ble/RaptPillParserTest.kt
+++ b/app/src/test/java/com/brewthings/app/data/ble/RaptPillParserTest.kt
@@ -1,7 +1,7 @@
 package com.brewthings.app.data.ble
 
-import junit.framework.TestCase.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class RaptPillParserTest {
     @Test

--- a/app/src/test/java/com/brewthings/app/utils/Moshi.kt
+++ b/app/src/test/java/com/brewthings/app/utils/Moshi.kt
@@ -1,0 +1,25 @@
+package com.brewthings.app.utils
+
+import com.karumi.kotlinsnapshot.core.SerializationModule
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+
+object MoshiSerializer : SerializationModule {
+    private val adapter: JsonAdapter<Any> = defaultMoshiBuilder {}
+        .build()
+        .adapter(Any::class.java).indent("  ")
+
+    override fun serialize(value: Any?): String = when (value) {
+        is Pair<*, *> -> serialize(listOf(value.first, value.second))
+        else -> adapter.toJson(value)
+    }
+}
+
+fun defaultMoshiBuilder(scope: Moshi.Builder.() -> Unit = {}): Moshi.Builder {
+    val builder = Moshi.Builder()
+    scope(builder)
+    return builder
+        .add(KotlinJsonAdapterFactory()) // because of presedence this should be added last
+        ?: throw RuntimeException("failed to create default moshi builder")
+}

--- a/app/src/test/java/com/brewthings/app/utils/SnapshotUtils.kt
+++ b/app/src/test/java/com/brewthings/app/utils/SnapshotUtils.kt
@@ -1,0 +1,33 @@
+package com.brewthings.app.utils
+
+import com.karumi.kotlinsnapshot.KotlinSnapshot
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import org.junit.jupiter.api.TestInfo
+import java.nio.file.Paths
+import kotlin.reflect.KClass
+
+inline infix fun <reified T> T.shouldMatchSnapshot(testInfo: TestInfo) {
+    val className: KClass<out Any> = testInfo.testClass.get().kotlin
+    val serialized: String = JsonSerializationConfig.encodeToString(serializer(), this)
+    KotlinSnapshot(
+        testClassAsDirectory = true,
+        snapshotsFolder = pathForTest(className.qualifiedName),
+    ).matchWithSnapshot(
+        value = serialized,
+        snapshotName = testInfo.testMethod.get().name
+    )
+}
+
+fun pathForTest(qualifiedName: String?): String {
+    val dir = "/src/test/java"
+    val snapshotsFolder = qualifiedName?.replace(".", "/")
+    return Paths.get(dir, snapshotsFolder).parent.toString()
+}
+
+val JsonSerializationConfig: Json = Json {
+    prettyPrint = true
+    isLenient = true
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,12 +16,16 @@ googleServices = "4.4.2"
 lifecycleRuntimeKtx = "2.7.0"
 kable = "0.31.1"
 koin = "3.5.6"
-mockk = "1.12.5"
+kotest = "5.9.1"
 kotlin = "1.9.20"
+kotlinsnapshot = "2.3.0"
 material = "1.12.0"
+mockk = "1.12.5"
+moshi = "1.14.0"
 mpAndroidChart = "v3.1.0"
 navigation = "2.7.7"
 junit = "4.13.2"
+jupiter = "5.10.2"
 room = "2.6.1"
 kotlinxSerializationJson = "1.6.3"
 kotlinxDatetime = "0.6.0"
@@ -98,5 +102,11 @@ room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 toml4j = { group = "com.moandjiezana.toml", name = "toml4j", version.ref = "toml4j" }
 
 # Test
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotest-junit5 = { group = "io.kotest", name = "kotest-runner-junit5-jvm", version.ref = "kotest" }
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "jupiter" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "jupiter" }
+junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "jupiter" }
+karumi = { group = "com.karumi.kotlinsnapshot", name = "core", version.ref = "kotlinsnapshot" }
 mockk = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+serialization-moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
+serialization-moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }


### PR DESCRIPTION
## WHAT 

- Adds snapshots as a comparison tool for test results

## WHY 

- Some tests require lot of assertions to get through. The snapshot creates a Json out of the operation result, stores it, and compares it every time the test runs.

NB: The snapshot gets created regardless the test is right or wrong, so be sure to check the result first.
NBB: It fails with dynamic values (example timestamp.now())