### PR TITLE
Material themes fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,9 +117,6 @@ dependencies {
     // AndroidX AppCompat
     implementation(libs.app.compat)
 
-    // Google Material Components
-    implementation(libs.material)
-
     // AndroidX Lifecycle
     implementation(libs.lifecycle.runtime.ktx)
 
@@ -141,7 +138,6 @@ dependencies {
     implementation(libs.navigation.fragment)
 
     // Material
-    implementation(libs.compose.material)
     implementation(libs.compose.material3)
 
     // Kable

--- a/app/src/main/java/com/brewthings/app/ui/components/ExpandableCard.kt
+++ b/app/src/main/java/com/brewthings/app/ui/components/ExpandableCard.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/java/com/brewthings/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/brewthings/app/ui/theme/Theme.kt
@@ -30,15 +30,9 @@ private val LightColorScheme = lightColorScheme(
 @Composable
 fun BrewthingsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ koin = "3.5.6"
 kotest = "5.9.1"
 kotlin = "1.9.20"
 kotlinsnapshot = "2.3.0"
-material = "1.12.0"
 mockk = "1.13.7"
 moshi = "1.14.0"
 mpAndroidChart = "v3.1.0"
@@ -54,9 +53,6 @@ accompanist-permissions = { group = "com.google.accompanist", name = "accompanis
 # AndroidX AppCompat
 app-compat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appCompat" }
 
-# Google Material Components
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-
 # AndroidX Lifecycle
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 
@@ -89,7 +85,6 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # Material Design for Jetpack Compose
-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3-android", version.ref = "composeMaterial3" }
 
 # MPAndroidChart


### PR DESCRIPTION
##What

- Removes the dynamicColor option. 
- Removes Material1

##Why

- The dynamicColor option just didn't work and was preventing from accessing the custom MaterialTheme falling back to the default one.
- Replaced all the Material components with the Material3 ones.