### PR TITLE
Measured velocity bug fix

### DIFF
--- a/app/src/main/java/com/brewthings/app/data/ble/RaptPillParser.kt
+++ b/app/src/main/java/com/brewthings/app/data/ble/RaptPillParser.kt
@@ -2,6 +2,7 @@ package com.brewthings.app.data.ble
 
 import com.brewthings.app.data.model.ScannedRaptPillData
 import com.brewthings.app.data.utils.toUShort
+import com.brewthings.app.util.validateVelocity
 import kotlinx.datetime.Clock
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -76,7 +77,7 @@ object RaptPillParser {
             timestamp = Clock.System.now(),
             temperature = (temperature / 128.0 - 273.15).toFloat(),
             gravity = gravity,
-            rawVelocity = if (gravityVelocityValid) gravityVelocity else null,
+            rawVelocity = if (gravityVelocityValid && gravityVelocity.validateVelocity()) gravityVelocity else null,
             x = x,
             y = y,
             z = z,

--- a/app/src/main/java/com/brewthings/app/data/model/RaptPillData.kt
+++ b/app/src/main/java/com/brewthings/app/data/model/RaptPillData.kt
@@ -2,7 +2,6 @@ package com.brewthings.app.data.model
 
 import com.brewthings.app.data.domain.BrewStage
 import com.brewthings.app.data.domain.SensorWithTiltReadings
-import com.brewthings.app.util.sanitizeVelocity
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
@@ -20,5 +19,5 @@ data class RaptPillData(
     override val isFG: Boolean,
     override val isFeeding: Boolean,
 ) : SensorWithTiltReadings, BrewStage {
-    override val gravityVelocity: Float? = rawVelocity?.sanitizeVelocity()
+    override val gravityVelocity: Float? = rawVelocity
 }

--- a/app/src/main/java/com/brewthings/app/data/model/ScannedRaptPillData.kt
+++ b/app/src/main/java/com/brewthings/app/data/model/ScannedRaptPillData.kt
@@ -1,7 +1,6 @@
 package com.brewthings.app.data.model
 
 import com.brewthings.app.data.domain.SensorWithTiltReadings
-import com.brewthings.app.util.sanitizeVelocity
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
@@ -16,5 +15,5 @@ data class ScannedRaptPillData(
     override val z: Float,
     override val battery: Float,
 ) : SensorWithTiltReadings {
-    override val gravityVelocity: Float? = rawVelocity?.sanitizeVelocity()
+    override val gravityVelocity: Float? = rawVelocity
 }

--- a/app/src/main/java/com/brewthings/app/util/Calculations.kt
+++ b/app/src/main/java/com/brewthings/app/util/Calculations.kt
@@ -16,12 +16,9 @@ fun calculateVelocity(previousData: RaptPillData?, fgData: RaptPillData): Float?
     val gpDrop = (fgData.gravity - previousData.gravity) * 1000f
     val daysBetween = (fgData.timestamp.epochSeconds - previousData.timestamp.epochSeconds).toFloat() / 86_400f
     val velocity = gpDrop / daysBetween
-    return velocity.sanitizeVelocity()
+    if (velocity.validateVelocity()) return velocity else return null
 }
 
-fun Float.sanitizeVelocity(): Float? =
-    if (isInfinite() || isNaN() || this > 0 || this < -100) {
-        null // Invalid velocity.
-    } else {
-        -1 * this // Invert the sign, to make it more intuitive.
-    }
+fun Float.validateVelocity(): Boolean = (isInfinite() || isNaN() || this > 0 || this < -100)
+
+fun Float.invertVelocity(): Float = -this

--- a/app/src/main/java/com/brewthings/app/util/Calculations.kt
+++ b/app/src/main/java/com/brewthings/app/util/Calculations.kt
@@ -16,7 +16,7 @@ fun calculateVelocity(previousData: RaptPillData?, fgData: RaptPillData): Float?
     val gpDrop = (fgData.gravity - previousData.gravity) * 1000f
     val daysBetween = (fgData.timestamp.epochSeconds - previousData.timestamp.epochSeconds).toFloat() / 86_400f
     val velocity = gpDrop / daysBetween
-    if (velocity.validateVelocity()) return velocity else return null
+    return velocity.takeIf { it.validateVelocity() }
 }
 
 fun Float.validateVelocity(): Boolean = isInfinite() || isNaN() || this > 0 || this < -100

--- a/app/src/main/java/com/brewthings/app/util/Calculations.kt
+++ b/app/src/main/java/com/brewthings/app/util/Calculations.kt
@@ -19,6 +19,6 @@ fun calculateVelocity(previousData: RaptPillData?, fgData: RaptPillData): Float?
     if (velocity.validateVelocity()) return velocity else return null
 }
 
-fun Float.validateVelocity(): Boolean = (isInfinite() || isNaN() || this > 0 || this < -100)
+fun Float.validateVelocity(): Boolean = isInfinite() || isNaN() || this > 0 || this < -100
 
 fun Float.invertVelocity(): Float = -this


### PR DESCRIPTION
## What

- Breaks down salitizeVelocity in validateVelocity and invertVelocity

## Why

- A recent change that inverted the velocity sign prior to database persistence resulted in a bug. When retrieved and sanitized again, the inverted sign was incorrectly stripped, leading to data loss. This separation provides distinct control over validation and inversion, preventing future issues.